### PR TITLE
feat(mcs): add endpoint to convert precomputed tallies to sems export

### DIFF
--- a/converter/SEMSoutput.py
+++ b/converter/SEMSoutput.py
@@ -54,6 +54,8 @@ YESNO_CANDIDATES = [
     ## TODO
 ]
 
+INTERNAL_WRITE_IN_ID = '__write-in'
+
 CVR_FIELDS = ["county_id", "precinct_id", "contest_id", "candidate_id"]
 CANDIDATE_FIELDS = ["county_id", "contest_id", "candidate_id"]
 
@@ -67,12 +69,151 @@ def find_contest(contests, contest_id):
         if c['type'] == 'ms-either-neither' and c['eitherNeitherContestId'] == contest_id:
             return {"id": c['eitherNeitherContestId'],
                     "title": c['title'],
-                    "options": c['eitherNeitherOptions']}
+                    "type": "yesno",
+                    "yesOption": c['eitherOption'],
+                    "noOption": c['neitherOption'],
+                    "districtId": c['districtId'],
+                    "options": c['eitherNeitherOptions'] if 'eitherNeitherOptions' in c else None}
         if c['type'] == 'ms-either-neither' and c['pickOneContestId'] == contest_id:
             return {"id": c['pickOneContestId'],
                     "title": c["title"],
-                    "options": c['pickOneOptions']}
+                    "type": "yesno",
+                    "yesOption": c['firstOption'],
+                    "noOption": c['secondOption'],
+                    "districtId": c['districtId'],
+                    "options": c['pickOneOptions'] if 'pickOneOptions' in c else None}
     
+
+def process_tallies_file(election_file_path, vx_results_file_path):
+    election = json.loads(open(election_file_path, "r").read())
+    tallies = json.loads(open(vx_results_file_path, "r").read())
+
+    contests = election["contests"]
+    ballot_styles = election["ballotStyles"]
+    precincts = election["precincts"]
+    parties = election["parties"] + [NOPARTY_PARTY]
+    county_id = election["county"]["id"]
+    tallies_by_precinct = tallies["talliesByPrecinct"]
+
+    contests_by_precinct = {p["id"]: [] for p in precincts}
+    for contest in contests:
+        contest_ballot_styles = [bs for bs in ballot_styles if contest["districtId"] in bs["districts"]]
+        contest_precincts = set()
+        [contest_precincts.update(bs["precincts"]) for bs in contest_ballot_styles]
+        for precinct in contest_precincts:
+            if contest["type"] == "ms-either-neither":
+                contests_by_precinct[precinct].append(contest["eitherNeitherContestId"])
+                contests_by_precinct[precinct].append(contest["pickOneContestId"])
+            else:
+                contests_by_precinct[precinct].append(contest["id"])
+
+    rows_to_write = []
+    for precinct in sorted(precincts, key=lambda precinct: precinct["id"]):
+        precinct_id = precinct["id"]
+        contest_tallies = tallies_by_precinct[precinct_id] if precinct_id in tallies_by_precinct else {}
+        contests_to_check = contests_by_precinct[precinct_id]
+        for contest_id in sorted(contests_to_check):
+            contest_tally = contest_tallies[contest_id] if contest_id in contest_tallies else {}
+            contest = find_contest(contests, contest_id)
+            
+            contest_party_id = contest["partyId"] if "partyId" in contest else None
+            contest_party = [p for p in parties if p["id"] == contest_party_id][0] if contest_party_id is not None else None
+
+            rows_for_contest = []
+            base_row_data = [
+                county_id,
+                precinct_id,
+                contest_id,
+                contest["title"].replace("\n", "\\n"),
+                contest_party_id or "0",
+                contest_party["abbrev"] if contest_party is not None else "NP"
+            ]
+            
+            # Add undervote and overvote row from metadata
+            metadata = contest_tally["metadata"] if "metadata" in contest_tally else {}
+            overvotes_row = base_row_data.copy()
+            overvotes_row.extend([
+                OVERVOTE_CANDIDATE["id"],
+                OVERVOTE_CANDIDATE["name"],
+                "0",
+                "NP",
+                metadata["overvotes"] if "overvotes" in metadata else 0
+            ])
+            rows_for_contest.append(overvotes_row)
+            undervotes_row = base_row_data.copy()
+            undervotes_row.extend([
+                UNDERVOTE_CANDIDATE["id"],
+                UNDERVOTE_CANDIDATE["name"],
+                "0",
+                "NP",
+                metadata["undervotes"] if "undervotes" in metadata else 0
+            ])
+            rows_for_contest.append(undervotes_row)
+
+            option_tallies = contest_tally["tallies"] if "tallies" in contest_tally else {}
+            if contest["type"] == "candidate":
+                options = contest["candidates"].copy()
+                if contest["allowWriteIns"]:
+                    options.append(WRITEIN_CANDIDATE)
+                for option in options:
+                    if option == WRITEIN_CANDIDATE:
+                        count = option_tallies[INTERNAL_WRITE_IN_ID] if INTERNAL_WRITE_IN_ID in option_tallies else 0
+                    else:
+                        count = option_tallies[option["id"]] if option["id"] in option_tallies else 0
+
+                    option_party_id = option["partyId"] if "partyId" in option else None
+                    option_party = [p for p in parties if p["id"] == option_party_id][0] if option_party_id is not None else None
+                    candidate_row = base_row_data.copy()
+                    candidate_row.extend([
+                        option["id"],
+                        option.get("name", option.get("label")),
+                        option_party_id or "0",
+                        option_party["abbrev"] if option_party is not None else "NP",
+                        count
+                    ])
+                    rows_for_contest.append(candidate_row)
+
+            elif contest["type"] == "yesno":
+                # get ids for yes option and no option
+                yes_option = contest["yesOption"]
+                no_option = contest["noOption"]
+                yes_count = option_tallies["yes"] if "yes" in option_tallies else 0
+                no_count = option_tallies["no"] if "no" in option_tallies else 0
+                yes_row = base_row_data.copy()
+                yes_row.extend([
+                    yes_option["id"],
+                    yes_option.get("name", yes_option.get("label")),
+                    "0",
+                    "NP",
+                    yes_count
+                ])
+                rows_for_contest.append(yes_row)
+
+                no_row = base_row_data.copy()
+                no_row.extend([
+                    no_option["id"],
+                    no_option.get("name", no_option.get("label")),
+                    "0",
+                    "NP",
+                    no_count
+                ])
+                rows_for_contest.append(no_row)
+            # Append rows sorted by candidate ID
+            for row in sorted(rows_for_contest, key=lambda row: row[6]):
+                rows_to_write.append(row)
+
+
+    sems_io = io.StringIO()
+    for row in rows_to_write:
+        # a whole rigamarole because SEMS needs a trailing comma
+        row_bytesio = io.StringIO()
+        sems_row_writer = csv.writer(row_bytesio, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL)
+        sems_row_writer.writerow(row)
+    
+        sems_io.write(row_bytesio.getvalue().strip('\r\n'))
+        sems_io.write(",\r\n")
+
+    return sems_io.getvalue()
 
 def process_results_file(election_file_path, vx_results_file_path):
     election = json.loads(open(election_file_path,"r").read())
@@ -275,7 +416,6 @@ def process_results_file(election_file_path, vx_results_file_path):
         # this is the placeholder row
         if not CVR_candidate_id:
             count = 0
-            
         # a whole rigamarole because SEMS needs a trailing comma
         row_bytesio = io.StringIO()
         sems_row_writer = csv.writer(row_bytesio, delimiter=',', quotechar='"', quoting=csv.QUOTE_ALL)

--- a/sample_files/10_8-26-2020-b-tallies.json
+++ b/sample_files/10_8-26-2020-b-tallies.json
@@ -1,0 +1,632 @@
+{
+  "talliesByPrecinct": {
+    "6522": {
+      "750000015": {
+        "tallies": { "yes": 7, "no": 11 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 19 }
+      },
+      "750000016": {
+        "tallies": { "yes": 11, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 19 }
+      },
+      "750000017": {
+        "tallies": { "yes": 10, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 19 }
+      },
+      "750000018": {
+        "tallies": { "yes": 6, "no": 13 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 19 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 5, "775031993": 13, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 19 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 8, "775031979": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 1, "undervotes": 2, "ballots": 19 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 9,
+          "775031988": 4,
+          "775031989": 5,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 19 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 8,
+          "775031986": 2,
+          "775031990": 8,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 19 }
+      },
+      "775020903": {
+        "tallies": { "775032021": 9, "775032022": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 2, "undervotes": 2, "ballots": 19 }
+      },
+      "775020904": {
+        "tallies": { "775032023": 19, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 19 }
+      }
+    },
+    "6524": {
+      "750000015": {
+        "tallies": { "yes": 3, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000016": {
+        "tallies": { "yes": 2, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000018": {
+        "tallies": { "yes": 4, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 1, "775031993": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 2,
+          "775031989": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 7 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 7 }
+      }
+    },
+    "6525": {
+      "750000015": {
+        "tallies": { "yes": 6, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "750000016": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "750000017": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "750000018": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 6, "775031979": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 11 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 4,
+          "775031988": 4,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 11 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 3,
+          "775031986": 6,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 11 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 5, "775032020": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 11 }
+      }
+    },
+    "6526": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000016": {
+        "tallies": { "yes": 3, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 6 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "750000018": {
+        "tallies": { "yes": 5, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 5, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 1,
+          "775031988": 4,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 8 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 1,
+          "775031990": 5,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 8 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      }
+    },
+    "6527": {
+      "750000015": {
+        "tallies": { "yes": 3, "no": 1 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 5 }
+      },
+      "750000016": {
+        "tallies": { "yes": 0, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 5 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 5 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 1, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 0,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 5 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 0,
+          "775031990": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 5 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      }
+    },
+    "6528": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 4, "no": 1 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 3, "no": 3 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 7 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 6, "775031993": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 1, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 1, "undervotes": 1, "ballots": 7 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 2,
+          "775031989": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 7 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 7 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 3, "775032017": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      }
+    },
+    "6529": {
+      "750000015": {
+        "tallies": { "yes": 5, "no": 4 },
+        "metadata": { "overvotes": 2, "undervotes": 1, "ballots": 12 }
+      },
+      "750000016": {
+        "tallies": { "yes": 4, "no": 5 },
+        "metadata": { "overvotes": 2, "undervotes": 1, "ballots": 12 }
+      },
+      "750000017": {
+        "tallies": { "yes": 4, "no": 6 },
+        "metadata": { "overvotes": 1, "undervotes": 1, "ballots": 12 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 8 },
+        "metadata": { "overvotes": 2, "undervotes": 0, "ballots": 12 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 8, "775031993": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 10, "775031979": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 5,
+          "775031988": 3,
+          "775031989": 4,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 3,
+          "775031986": 7,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 11, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 12 }
+      }
+    },
+    "6532": {
+      "750000015": {
+        "tallies": { "yes": 4, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "750000016": {
+        "tallies": { "yes": 5, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "750000017": {
+        "tallies": { "yes": 5, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 9 }
+      },
+      "750000018": {
+        "tallies": { "yes": 6, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 9 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 1, "775031993": 7, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 9 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 3,
+          "775031989": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 4,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 9 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 3, "775032020": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 9 }
+      }
+    },
+    "6534": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000016": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000017": {
+        "tallies": { "yes": 1, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 5 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 1,
+          "775031989": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 1, "775032017": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      }
+    },
+    "6536": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000016": {
+        "tallies": { "yes": 0, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000017": {
+        "tallies": { "yes": 0, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 1, "775031993": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 2, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 0,
+          "775031988": 1,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 0,
+          "775031986": 2,
+          "775031990": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 1, "775032017": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      }
+    },
+    "6537": {
+      "750000015": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000016": {
+        "tallies": { "yes": 1, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000017": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 2 },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 5 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 1, "775031979": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 5 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 0,
+          "775031989": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 1, "ballots": 5 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 2,
+          "775031990": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 0, "ballots": 5 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 2, "775032020": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      }
+    },
+    "6538": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 1, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 6 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 5, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 1,
+          "775031989": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 2,
+          "775031990": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      }
+    },
+    "6539": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000016": {
+        "tallies": { "yes": 2, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000017": {
+        "tallies": { "yes": 1, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "750000018": {
+        "tallies": { "yes": 1, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 0, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 0, "775031979": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 0,
+          "775031988": 2,
+          "775031989": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 1,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      }
+    }
+  }
+}

--- a/sample_files/10_8-26-2020-tallies.json
+++ b/sample_files/10_8-26-2020-tallies.json
@@ -1,0 +1,632 @@
+{
+  "talliesByPrecinct": {
+    "6522": {
+      "750000015": {
+        "tallies": { "yes": 8, "no": 10 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "750000016": {
+        "tallies": { "yes": 9, "no": 7 },
+        "metadata": { "overvotes": 1, "undervotes": 1, "ballots": 18 }
+      },
+      "750000017": {
+        "tallies": { "yes": 11, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "750000018": {
+        "tallies": { "yes": 10, "no": 8 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 7, "775031993": 11, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 8, "775031979": 10, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 9,
+          "775031988": 3,
+          "775031989": 6,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 8,
+          "775031990": 8,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020903": {
+        "tallies": { "775032021": 8, "775032022": 10, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      },
+      "775020904": {
+        "tallies": { "775032023": 18, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 18 }
+      }
+    },
+    "6524": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "750000016": {
+        "tallies": { "yes": 3, "no": 6 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "750000017": {
+        "tallies": { "yes": 3, "no": 6 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "750000018": {
+        "tallies": { "yes": 4, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 5, "775031993": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 5, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 1,
+          "775031989": 5,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 4,
+          "775031986": 2,
+          "775031990": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 9, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 9 }
+      }
+    },
+    "6525": {
+      "750000015": {
+        "tallies": { "yes": 6, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000016": {
+        "tallies": { "yes": 6, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 2, "775031979": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 2,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 7 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 0,
+          "775031986": 4,
+          "775031990": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 1, "775032020": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      }
+    },
+    "6526": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 5, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 6 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 0, "775031979": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 6 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 1,
+          "775031988": 3,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 2,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      }
+    },
+    "6527": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 10 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "750000016": {
+        "tallies": { "yes": 5, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "750000017": {
+        "tallies": { "yes": 3, "no": 9 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "750000018": {
+        "tallies": { "yes": 5, "no": 7 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 4, "775031993": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 8, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 5,
+          "775031988": 5,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 5,
+          "775031986": 5,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 12, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 12 }
+      }
+    },
+    "6528": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "750000016": {
+        "tallies": { "yes": 2, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "750000017": {
+        "tallies": { "yes": 2, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 1, "775031979": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 1,
+          "775031989": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 0,
+          "775031986": 2,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 4, "775032017": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      }
+    },
+    "6529": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 6 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "750000016": {
+        "tallies": { "yes": 6, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "750000017": {
+        "tallies": { "yes": 4, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "750000018": {
+        "tallies": { "yes": 4, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 5, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 2, "775031979": 6, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 2,
+          "775031989": 4,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 2,
+          "775031990": 5,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 8 }
+      }
+    },
+    "6532": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000016": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000017": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 4, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 2,
+          "775031988": 1,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 3,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 3, "775032020": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 5 }
+      }
+    },
+    "6534": {
+      "750000015": {
+        "tallies": { "yes": 1, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 1, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 4, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000018": {
+        "tallies": { "yes": 3, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 3, "775031993": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 5, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 3,
+          "775031989": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 3,
+          "775031986": 2,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 2, "775032017": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      }
+    },
+    "6536": {
+      "750000015": {
+        "tallies": { "yes": 3, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 4, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000018": {
+        "tallies": { "yes": 4, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 4, "775031993": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 3, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 1,
+          "775031988": 2,
+          "775031989": 3,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 4,
+          "775031990": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "775020900": {
+        "tallies": { "775032016": 5, "775032017": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      }
+    },
+    "6537": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000016": {
+        "tallies": { "yes": 3, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 6 }
+      },
+      "750000017": {
+        "tallies": { "yes": 4, "no": 2 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 7 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 2, "775031993": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 3, "775031979": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 2,
+          "775031989": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 1,
+          "775031986": 2,
+          "775031990": 4,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      },
+      "775020902": {
+        "tallies": { "775032019": 3, "775032020": 4, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 7 }
+      }
+    },
+    "6538": {
+      "750000015": {
+        "tallies": { "yes": 2, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "750000016": {
+        "tallies": { "yes": 1, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "750000017": {
+        "tallies": { "yes": 1, "no": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "750000018": {
+        "tallies": { "yes": 2, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 1, "775031993": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 1, "775031979": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 0,
+          "775031988": 1,
+          "775031989": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 0,
+          "775031986": 0,
+          "775031990": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      },
+      "775020899": {
+        "tallies": { "775032015": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 2 }
+      }
+    },
+    "6539": {
+      "750000015": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "750000016": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "750000017": {
+        "tallies": { "yes": 5, "no": 5 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "750000018": {
+        "tallies": { "yes": 7, "no": 3 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "775020870": {
+        "tallies": { "775031976": 5, "775031993": 5, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "775020872": {
+        "tallies": { "775031978": 2, "775031979": 8, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "775020876": {
+        "tallies": {
+          "775031987": 3,
+          "775031988": 3,
+          "775031989": 4,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "775020877": {
+        "tallies": {
+          "775031985": 2,
+          "775031986": 3,
+          "775031990": 5,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      },
+      "775020901": {
+        "tallies": { "775032018": 10, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 10 }
+      }
+    }
+  }
+}

--- a/sample_files/10_tallies.json
+++ b/sample_files/10_tallies.json
@@ -1,0 +1,1208 @@
+{
+  "talliesByPrecinct": {
+    "6522": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 1, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 1, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 1,
+          "575030430": 1,
+          "575032129": 0,
+          "575032130": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 1, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      },
+      "575021537": {
+        "tallies": { "575032596": 0, "575032597": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 3, "ballots": 3 }
+      }
+    },
+    "6524": {
+      "575020970": {
+        "tallies": { "575031910": 2, "575031911": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 1, "__write-in": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 1, "575031917": 1, "__write-in": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 3, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 1,
+          "575032129": 1,
+          "575032130": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 1, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 2, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 2, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 1, "__write-in": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 1, "575032586": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "575021533": {
+        "tallies": { "575032588": 1, "575032589": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      }
+    },
+    "6525": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021536": {
+        "tallies": { "575032594": 0, "575032595": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6526": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021535": {
+        "tallies": { "575032592": 0, "575032593": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6527": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021533": {
+        "tallies": { "575032588": 0, "575032589": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6528": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021534": {
+        "tallies": { "575032590": 0, "575032591": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6529": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021535": {
+        "tallies": { "575032592": 0, "575032593": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6532": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021536": {
+        "tallies": { "575032594": 0, "575032595": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6534": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021534": {
+        "tallies": { "575032590": 0, "575032591": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6536": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021534": {
+        "tallies": { "575032590": 0, "575032591": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6537": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021536": {
+        "tallies": { "575032594": 0, "575032595": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6538": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021529": {
+        "tallies": { "575032583": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021531": {
+        "tallies": { "575032585": 0, "575032586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021533": {
+        "tallies": { "575032588": 0, "575032589": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "6539": {
+      "575020970": {
+        "tallies": { "575031910": 0, "575031911": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020971": {
+        "tallies": { "575031912": 0, "575031913": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020972": {
+        "tallies": { "575031914": 0, "575031915": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020973": {
+        "tallies": { "575031916": 0, "575031917": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020974": {
+        "tallies": { "575031918": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020975": {
+        "tallies": { "575031919": 0, "575031920": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575020980": {
+        "tallies": { "575031925": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021007": {
+        "tallies": { "575031962": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021090": {
+        "tallies": { "575032061": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021144": {
+        "tallies": { "575032121": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021151": {
+        "tallies": { "575032127": 0, "575032128": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021152": {
+        "tallies": {
+          "575030384": 0,
+          "575030430": 0,
+          "575032129": 0,
+          "575032130": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021153": {
+        "tallies": { "575032131": 0, "575032132": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021524": {
+        "tallies": { "575032576": 0, "575032577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021525": {
+        "tallies": { "575032578": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021526": {
+        "tallies": { "575032579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021527": {
+        "tallies": { "575032580": 0, "575032581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021528": {
+        "tallies": { "575032582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021530": {
+        "tallies": { "575032584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021532": {
+        "tallies": { "575032587": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "575021535": {
+        "tallies": { "575032592": 0, "575032593": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    }
+  }
+}

--- a/sample_files/53_tallies.json
+++ b/sample_files/53_tallies.json
@@ -1,0 +1,3531 @@
+{
+  "talliesByPrecinct": {
+    "852": {
+      "775013566": {
+        "tallies": { "575021682": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 1, "775021492": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 2,
+          "575021572": 1,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 2, "575021575": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 2, "575021577": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 1, "575021579": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 2, "575021584": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 1, "575021586": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 1, "775021504": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 1,
+          "775022271": 2,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 1, "775022285": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 2, "775022288": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014109": {
+        "tallies": { "775022300": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014110": {
+        "tallies": { "775022301": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      }
+    },
+    "853": {
+      "775013566": {
+        "tallies": { "575021682": 1, "__write-in": 1 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 2,
+          "575021572": 1,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 2, "575021577": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 2,
+          "775022278": 0,
+          "775022279": 1,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 2, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 3 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 1, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 2, "ballots": 3 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014113": {
+        "tallies": {
+          "775022305": 0,
+          "775022306": 1,
+          "775022307": 2,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      }
+    },
+    "857": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014109": {
+        "tallies": { "775022300": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014110": {
+        "tallies": { "775022301": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "858": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014113": {
+        "tallies": {
+          "775022305": 0,
+          "775022306": 0,
+          "775022307": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "860": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013659": {
+        "tallies": { "575021755": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014109": {
+        "tallies": { "775022300": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014110": {
+        "tallies": { "775022301": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "861": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014108": {
+        "tallies": {
+          "775022297": 0,
+          "775022298": 0,
+          "775022299": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "862": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013659": {
+        "tallies": { "575021755": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014109": {
+        "tallies": { "775022300": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014110": {
+        "tallies": { "775022301": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "865": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014106": {
+        "tallies": { "775022295": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014107": {
+        "tallies": { "775022296": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "866": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014113": {
+        "tallies": {
+          "775022305": 0,
+          "775022306": 0,
+          "775022307": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "867": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014108": {
+        "tallies": {
+          "775022297": 0,
+          "775022298": 0,
+          "775022299": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "869": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014106": {
+        "tallies": { "775022295": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014107": {
+        "tallies": { "775022296": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "872": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014111": {
+        "tallies": { "775022302": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014112": {
+        "tallies": { "775022303": 0, "775022304": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "873": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014113": {
+        "tallies": {
+          "775022305": 0,
+          "775022306": 0,
+          "775022307": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "874": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014111": {
+        "tallies": { "775022302": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014112": {
+        "tallies": { "775022303": 0, "775022304": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "876": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014106": {
+        "tallies": { "775022295": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014107": {
+        "tallies": { "775022296": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "750000053": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014111": {
+        "tallies": { "775022302": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014112": {
+        "tallies": { "775022303": 0, "775022304": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "750000054": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013659": {
+        "tallies": { "575021755": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014106": {
+        "tallies": { "775022295": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014107": {
+        "tallies": { "775022296": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "750000055": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013660": {
+        "tallies": { "575021756": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014086": {
+        "tallies": { "775022266": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014087": {
+        "tallies": { "775022267": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014091": {
+        "tallies": {
+          "775022273": 0,
+          "775022274": 0,
+          "775022275": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014108": {
+        "tallies": {
+          "775022297": 0,
+          "775022298": 0,
+          "775022299": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "750000056": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013659": {
+        "tallies": { "575021755": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013769": {
+        "tallies": { "575021809": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014085": {
+        "tallies": { "775022263": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014090": {
+        "tallies": {
+          "775022270": 0,
+          "775022271": 0,
+          "775022272": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014109": {
+        "tallies": { "775022300": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014110": {
+        "tallies": { "775022301": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "750000058": {
+      "775013566": {
+        "tallies": { "575021682": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013573": {
+        "tallies": { "775021514": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013574": {
+        "tallies": { "775021515": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013667": {
+        "tallies": { "775021702": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013668": {
+        "tallies": { "775021703": 0, "775021704": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013738": {
+        "tallies": { "575021569": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013739": {
+        "tallies": { "575021570": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013740": {
+        "tallies": { "775021489": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013741": {
+        "tallies": { "775021490": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013742": {
+        "tallies": { "775021491": 0, "775021492": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013743": {
+        "tallies": {
+          "575021571": 0,
+          "575021572": 0,
+          "575021573": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013744": {
+        "tallies": { "575021574": 0, "575021575": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013745": {
+        "tallies": { "575021576": 0, "575021577": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013746": {
+        "tallies": { "575021578": 0, "575021579": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013747": {
+        "tallies": { "575021580": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013748": {
+        "tallies": { "575021581": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013749": {
+        "tallies": { "575021582": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013750": {
+        "tallies": { "575021583": 0, "575021584": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013751": {
+        "tallies": { "575021585": 0, "575021586": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013767": {
+        "tallies": { "575021807": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013768": {
+        "tallies": { "575021808": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013819": {
+        "tallies": { "775021501": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775013820": {
+        "tallies": { "775021503": 0, "775021504": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014088": {
+        "tallies": { "775022268": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014089": {
+        "tallies": { "775022269": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014092": {
+        "tallies": {
+          "775022276": 0,
+          "775022277": 0,
+          "775022278": 0,
+          "775022279": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014093": {
+        "tallies": { "775022280": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014094": {
+        "tallies": { "775022281": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014096": {
+        "tallies": { "775022283": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014097": {
+        "tallies": { "775022284": 0, "775022285": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014098": {
+        "tallies": { "775022286": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014099": {
+        "tallies": { "775022287": 0, "775022288": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014100": {
+        "tallies": { "775022289": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014101": {
+        "tallies": { "775022290": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014102": {
+        "tallies": { "775022291": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014103": {
+        "tallies": { "775022292": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014104": {
+        "tallies": { "775022293": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014105": {
+        "tallies": { "775022294": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014111": {
+        "tallies": { "775022302": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "775014112": {
+        "tallies": { "775022303": 0, "775022304": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    }
+  }
+}

--- a/sample_files/election-primary-sample-tallies.json
+++ b/sample_files/election-primary-sample-tallies.json
@@ -1,0 +1,340 @@
+{
+  "talliesByPrecinct": {
+    "20": {
+      "primary-constitution-head-of-party": {
+        "tallies": { "alice": 5, "bob": 3 },
+        "metadata": { "overvotes": 1, "undervotes": 2, "ballots": 11 }
+      }
+    },
+    "21": {
+      "102": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "president": {
+        "tallies": {
+          "barchi-hallaren": 1,
+          "cramer-vuocolo": 1,
+          "court-blumhardt": 0,
+          "boone-lian": 0,
+          "hildebrand-garritty": 0,
+          "patterson-lariviere": 0
+        },
+        "metadata": { "overvotes": 1, "undervotes": 1, "ballots": 4 }
+      },
+      "senator": {
+        "tallies": {
+          "weiford": 4,
+          "garriss": 0,
+          "wentworthfarthington": 0,
+          "hewetson": 0,
+          "martinez": 0,
+          "brown": 0,
+          "pound": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "representative-district-6": {
+        "tallies": {
+          "plunkard": 3,
+          "reeder": 1,
+          "schott": 0,
+          "tawney": 0,
+          "forrest": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "governor": {
+        "tallies": {
+          "franz": 4,
+          "harris": 0,
+          "bargmann": 0,
+          "abcock": 0,
+          "steelloy": 0,
+          "sharp": 0,
+          "wallace": 0,
+          "williams": 0,
+          "sharp-althea": 0,
+          "alpern": 0,
+          "windbeck": 0,
+          "greher": 0,
+          "alexander": 0,
+          "mitchell": 0,
+          "lee": 0,
+          "ash": 0,
+          "kennedy": 0,
+          "jackson": 0,
+          "brown": 0,
+          "teller": 0,
+          "ward": 0,
+          "murphy": 0,
+          "newman": 0,
+          "callanann": 0,
+          "york": 0,
+          "chandler": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "lieutenant-governor": {
+        "tallies": {
+          "norberg": 4,
+          "parks": 0,
+          "garcia": 0,
+          "qualey": 0,
+          "hovis": 0,
+          "zirkle": 0,
+          "davis": 0,
+          "freeman": 0,
+          "swan": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "secretary-of-state": {
+        "tallies": { "shamsi": 3, "talarico": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 1, "ballots": 4 }
+      },
+      "state-senator-district-31": {
+        "tallies": { "shiplett": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "state-assembly-district-54": {
+        "tallies": { "solis": 4, "keller": 0, "rangel": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "county-commissioners": {
+        "tallies": {
+          "argent": 0,
+          "witherspoonsmithson": 0,
+          "bainbridge": 0,
+          "hennessey": 0,
+          "savoy": 0,
+          "tawa": 0,
+          "tawa-mary": 0,
+          "rangel": 0,
+          "altman": 0,
+          "moore": 0,
+          "white": 0,
+          "schmidt": 0,
+          "smith": 0,
+          "marracini": 0,
+          "schreiner": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 8, "undervotes": 8, "ballots": 4 }
+      },
+      "county-registrar-of-wills": {
+        "tallies": { "ramachandrani": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "city-mayor": {
+        "tallies": { "white": 0, "seldon": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "city-council": {
+        "tallies": {
+          "eagle": 0,
+          "rupp": 0,
+          "shry": 0,
+          "barker": 0,
+          "davis": 0,
+          "smith": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "judicial-robert-demergue": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "judicial-elmer-hull": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-a": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-b": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-c": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "proposition-1": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "measure-101": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    },
+    "23": {
+      "102": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "president": {
+        "tallies": {
+          "barchi-hallaren": 3,
+          "cramer-vuocolo": 1,
+          "court-blumhardt": 0,
+          "boone-lian": 0,
+          "hildebrand-garritty": 0,
+          "patterson-lariviere": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "senator": {
+        "tallies": {
+          "weiford": 4,
+          "garriss": 0,
+          "wentworthfarthington": 0,
+          "hewetson": 0,
+          "martinez": 0,
+          "brown": 0,
+          "pound": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "representative-district-6": {
+        "tallies": {
+          "plunkard": 2,
+          "reeder": 2,
+          "schott": 0,
+          "tawney": 0,
+          "forrest": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "governor": {
+        "tallies": {
+          "franz": 4,
+          "harris": 0,
+          "bargmann": 0,
+          "abcock": 0,
+          "steelloy": 0,
+          "sharp": 0,
+          "wallace": 0,
+          "williams": 0,
+          "sharp-althea": 0,
+          "alpern": 0,
+          "windbeck": 0,
+          "greher": 0,
+          "alexander": 0,
+          "mitchell": 0,
+          "lee": 0,
+          "ash": 0,
+          "kennedy": 0,
+          "jackson": 0,
+          "brown": 0,
+          "teller": 0,
+          "ward": 0,
+          "murphy": 0,
+          "newman": 0,
+          "callanann": 0,
+          "york": 0,
+          "chandler": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "lieutenant-governor": {
+        "tallies": {
+          "norberg": 4,
+          "parks": 0,
+          "garcia": 0,
+          "qualey": 0,
+          "hovis": 0,
+          "zirkle": 0,
+          "davis": 0,
+          "freeman": 0,
+          "swan": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "secretary-of-state": {
+        "tallies": { "shamsi": 3, "talarico": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 3 }
+      },
+      "state-senator-district-31": {
+        "tallies": { "shiplett": 4 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "state-assembly-district-54": {
+        "tallies": { "solis": 4, "keller": 0, "rangel": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 4 }
+      },
+      "county-commissioners": {
+        "tallies": {
+          "argent": 4,
+          "witherspoonsmithson": 3,
+          "bainbridge": 2,
+          "hennessey": 1,
+          "savoy": 0,
+          "tawa": 0,
+          "tawa-mary": 0,
+          "rangel": 0,
+          "altman": 0,
+          "moore": 0,
+          "white": 0,
+          "schmidt": 0,
+          "smith": 0,
+          "marracini": 0,
+          "schreiner": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 6, "ballots": 4 }
+      },
+      "county-registrar-of-wills": {
+        "tallies": { "ramachandrani": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "city-mayor": {
+        "tallies": { "white": 0, "seldon": 0, "__write-in": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "city-council": {
+        "tallies": {
+          "eagle": 0,
+          "rupp": 0,
+          "shry": 0,
+          "barker": 0,
+          "davis": 0,
+          "smith": 0,
+          "__write-in": 0
+        },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "judicial-robert-demergue": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "judicial-elmer-hull": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-a": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-b": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "question-c": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "proposition-1": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      },
+      "measure-101": {
+        "tallies": { "yes": 0, "no": 0 },
+        "metadata": { "overvotes": 0, "undervotes": 0, "ballots": 0 }
+      }
+    }
+  }
+}

--- a/tests/test_SEMSoutput.py
+++ b/tests/test_SEMSoutput.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest, json, io, os
 
-from converter.SEMSoutput import process_results_file
+from converter.SEMSoutput import process_results_file, process_tallies_file
 
 PARENT_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), '..')
 SAMPLE_FILES = os.path.join(PARENT_DIR, 'sample_files')
@@ -11,21 +11,25 @@ TESTS = [
     {
         'election': 'general-election.json',
         'cvrs': '10_cvrs.csv',
+        'tallies': '10_tallies.json',
         'sems': '10_expected-sems-results.txt'
     },
     {
         'election': '10_8-26-2020-expected-election.json',
         'cvrs': '10_8-26-2020-cvrs.txt',
+        'tallies': '10_8-26-2020-tallies.json',
         'sems': '10_8-26-2020-expected-sems-output.txt',
     },
     {
         'election': '10_8-26-2020-expected-election.json',
         'cvrs': '10_8-26-2020-b-cvrs.txt',
+        'tallies': '10_8-26-2020-b-tallies.json',
         'sems': '10_8-26-2020-b-expected-sems-output.txt',
     },
     {
         'election': 'electionPrimarySample.json',
         'cvrs': 'election-primary-sample-cvrs.txt',
+        'tallies': 'election-primary-sample-tallies.json',
         'sems': 'election-primary-expected-results.csv',
     }
 ]
@@ -43,4 +47,16 @@ def test_general_results():
         expected_result_file = open(get_sample_file(test['sems']), "rb")
         expected_result = expected_result_file.read()
         
+        assert result.encode('utf-8') == expected_result
+
+def test_general_results_from_tallies():
+    for test in TESTS:
+        print("testing", test)
+        result = process_tallies_file(
+            get_sample_file(test['election']),
+            get_sample_file(test['tallies']))
+
+        expected_result_file = open(get_sample_file(test['sems']), "rb")
+        expected_result = expected_result_file.read()
+
         assert result.encode('utf-8') == expected_result


### PR DESCRIPTION
Adds a new set of endpoints to module-converter-sems to enable converted a json blob of precomputed tallies (see the sample files for the format) to a exported SEMs result. The outputted SEMs file are identical in content to the previously generated SEMs file HOWEVER the order of the lines is different. The order of the contests that we iterate through is different and within a contest there are some subtle changes in the order like having write ins be the last row instead of the first row, I'm assuming this doesn't matter but if necessary I can try to get the order to match up exactly. Because of the order changes you'll notice I have to do a bit more work in the tests to verify that the output files match the sample files in a order-ignorant manner. 

The outputted file will contain rows for all valid contests/candidates in the election even if the input tallies are missing certain contests or candidates, and will default to a count of 0 votes for anything unspecified. 

This does not yet remove the old endpoints for generating an export from CVR files, I will come back and remove that after switching election manager over to using this new endpoint. 